### PR TITLE
Fix pad func in AES

### DIFF
--- a/AES_MP128.py
+++ b/AES_MP128.py
@@ -14,7 +14,7 @@ def _enc_aes(k,v):
 
 def _pad_zero(v,l):
     tmp = v + bytes([0 for i in range(l)])
-    return tmp[0:l-1]
+    return tmp[0:l]
 
 def _ident(k):
     return k


### PR DESCRIPTION
pad func doesn't return the correct size of bytes